### PR TITLE
Ignore directories when finding executables

### DIFF
--- a/lib/src/shell_utils.dart
+++ b/lib/src/shell_utils.dart
@@ -217,7 +217,8 @@ String findExecutableSync(String command, List<String> paths) {
         }
       } else {
         var stats = File(commandPath).statSync();
-        if (stats.type != FileSystemEntityType.notFound) {
+        if (stats.type == FileSystemEntityType.file ||
+            stats.type == FileSystemEntityType.link) {
           // Check executable permission
           if (stats.mode & 0x49 != 0) {
             // binary 001001001


### PR DESCRIPTION
So I happen to have a `flutter` directory in my path. That is because I keep my programs on a generic `opt` dir that I added to my path. For some programs are just single file executables. Then, I added `opt/flutter/bin` to the path as well. When I do `flutter` on bash of course it ignores the `flutter` dir on `opt` and finds the file flutter in `opt/flutter/bin`.

However, in Linux, dirs that you can access are considered executable ([see here](https://askubuntu.com/questions/862289/difference-between-executable-directory-vs-executable-files)).

Thus your findExecutableSync matches the folder, returning the wrong path. I changed the check to ignore folders, so it should always work now :)