### PR TITLE
🐛 Fix `clone` in `ShellMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.5+1
+
+* Fix `clone` in `ShellMixin`.
+
 ## 0.12.5
 
 * requires dart sdk 2.18

--- a/lib/src/shell_common.dart
+++ b/lib/src/shell_common.dart
@@ -264,6 +264,7 @@ mixin ShellMixin implements ShellCore {
     return shell;
   }
 
+  @Deprecated('Use clone with options')
   Shell clone(
       {bool? throwOnError,
       String? workingDirectory,
@@ -278,7 +279,22 @@ mixin ShellMixin implements ShellCore {
       bool? verbose,
       bool? commandVerbose,
       bool? commentVerbose}) {
-    // TODO: implement clone
-    throw UnimplementedError();
+    return cloneWithOptions(
+      ShellOptions(
+        throwOnError: throwOnError ?? options.throwOnError,
+        workingDirectory: workingDirectory ?? options.workingDirectory,
+        environment: environment ?? options.environment,
+        includeParentEnvironment: includeParentEnvironment ?? true,
+        runInShell: runInShell ?? options.runInShell,
+        stdoutEncoding: stdoutEncoding ?? options.stdoutEncoding,
+        stderrEncoding: stderrEncoding ?? options.stderrEncoding,
+        stdin: stdin ?? options.stdin,
+        stdout: stdout ?? options.stdout,
+        stderr: stderr ?? options.stderr,
+        verbose: verbose ?? options.verbose,
+        commandVerbose: commandVerbose ?? options.commandVerbose,
+        commentVerbose: commentVerbose ?? options.commentVerbose,
+      ),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process_run
-version: 0.12.5
+version: 0.12.5+1
 description: Process run helpers for Linux/Win/Mac and which like feature for finding executables.
 homepage: https://github.com/tekartik/process_run.dart
 


### PR DESCRIPTION
`clone` has been marked as deprecated in `Shell`, but `ShellIo` uses the `clone` method from `ShellMixin`. So it shouldn't be unimplemented, but redirected to `cloneWithOptions`.