### PR TITLE
optimize reading config file.

### DIFF
--- a/lib/src/user_config.dart
+++ b/lib/src/user_config.dart
@@ -246,7 +246,11 @@ EnvFileConfig _loadFromPath(String path) {
   try {
     // Look for any config file in ~/tekartik/process_run/env.yaml
     try {
-      fileContent = File(path).readAsStringSync();
+      var configFile = File(path);
+
+      if (configFile.existsSync()) {
+        fileContent = configFile.readAsStringSync();
+      }
     } catch (e) {
       //  stderr.writeln('error reading env file $path $e');
     }


### PR DESCRIPTION
if the config file (~/tekartik/process_run/env.yaml) does not exist, an exception (PathNotFoundException) is thrown and captured by Sentry, it is not necessary to record this exception most of the time.